### PR TITLE
Project account dropdown for job composer

### DIFF
--- a/apps/myjobs/app/models/workflow.rb
+++ b/apps/myjobs/app/models/workflow.rb
@@ -1,4 +1,5 @@
 require 'find'
+require 'etc'
 
 class Workflow < ApplicationRecord
   has_many :jobs, class_name: "Job", dependent: :destroy
@@ -208,8 +209,21 @@ class Workflow < ApplicationRecord
   # Returns the optional user-entered account string
   #
   # @return [String, nil] the account string or nil if blank
-  def account
-    super.strip unless super.blank?
+  # def account
+  #   super.strip unless super.blank?
+  # end
+
+  def accounts_by_user
+    IO.popen('cat /home/ood/sacctmgr.txt') { |cmd|
+      cmd.map { |line|
+        acc = line.split('|')
+        acc[0] if acc[2] == Etc.getlogin
+      }.compact
+    }
+  end
+
+  def accounts
+    accounts_by_user.map { |x| [x, x] }
   end
 
   # Define tasks to do after staging template directory typically copy over

--- a/apps/myjobs/app/models/workflow.rb
+++ b/apps/myjobs/app/models/workflow.rb
@@ -214,10 +214,10 @@ class Workflow < ApplicationRecord
   # end
 
   def accounts_by_user
-    IO.popen('cat /home/ood/sacctmgr.txt') { |cmd|
+    IO.popen('sacctmgr -np show accounts withassoc format=account,user') { |cmd|
       cmd.map { |line|
         acc = line.split('|')
-        acc[0] if acc[2] == Etc.getlogin
+        acc[0] if acc[1] == Etc.getlogin
       }.compact
     }
   end

--- a/apps/myjobs/app/views/workflows/_edit_form_job_attrs.html.erb
+++ b/apps/myjobs/app/views/workflows/_edit_form_job_attrs.html.erb
@@ -4,9 +4,20 @@
 
 API at: https://github.com/bootstrap-ruby/rails-bootstrap-forms %>
 
-<%= f.text_field :account,
-        label: t('jobcomposer.options_account_title'),
-        help: t('jobcomposer.options_account_help') if Configuration.show_job_options_account_field?
+<%# f.select :account,
+        grouped_options_for_select(workflow.accounts, workflow.account),
+        { label: "Account" },
+        { class: "selectpicker", id: "workflow_account" }
+%>
+
+<%= f.select :account,
+        @workflow.accounts, {
+                label: "Account:",
+                :include_blank => false
+        }, {
+                class: "selectpicker",
+                id: "account_select"
+        }
 %>
 
 <% if Workflow.show_job_arrays? %>

--- a/apps/myjobs/app/views/workflows/_new_from_path_form.html.erb
+++ b/apps/myjobs/app/views/workflows/_new_from_path_form.html.erb
@@ -23,7 +23,7 @@
 
         <%= f.select :batch_host, OODClusters.map { |cluster| [ "#{cluster.metadata.title}", cluster.id ] }, { label: "Cluster:", :include_blank => true }, { class: "selectpicker", id: "batch_host_select" } %>
 
-        <%= f.text_field :account, help: "Account is an optional field. If not set, the account may be auto-set by the submit filter." %>
+        <%= f.select :account, workflow.accounts, { label: "Account:", :include_blank => false }, { class: "selectpicker", id: "account_select" } %>
       </div>
     </div>
 


### PR DESCRIPTION
Invokes sacctmgr to populate a dropdown of project accounts for use in submit scripts in the Job Composer app.